### PR TITLE
fix: resolve light mode issues, landing page, payment dialog, sidebar

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -45,61 +45,8 @@
 
 :root {
 	--radius: 0.625rem;
-}
 
-.dark,
-:root {
-	/* Dark theme - Neutral gray/charcoal theme */
-	--background: oklch(0.12 0.01 0);
-	--foreground: oklch(0.98 0.005 0);
-	--card: oklch(0.18 0.01 0);
-	--card-foreground: oklch(0.98 0.005 0);
-	--popover: oklch(0.18 0.01 0);
-	--popover-foreground: oklch(0.98 0.005 0);
-
-	/* COLOR SCHEME - Blend of Option 3 (Purple/Violet) and Option 6 (Indigo/Blue) */
-	/* Blue-Violet/Indigo-Purple - Professional yet creative, elegant and trustworthy */
-	--primary: oklch(0.63 0.17 270);
-	--primary-foreground: oklch(0.98 0.005 0);
-	--ring: oklch(0.58 0.19 270);
-	--accent: oklch(0.28 0.02 270);
-
-	--secondary: oklch(0.25 0.01 0);
-	--secondary-foreground: oklch(0.98 0.005 0);
-	--muted: oklch(0.25 0.01 0);
-	--muted-foreground: oklch(0.65 0.01 0);
-	--accent-foreground: oklch(0.98 0.005 0);
-	--destructive: oklch(0.65 0.22 25);
-	--border: oklch(1 0 0 / 12%);
-	--input: oklch(1 0 0 / 15%);
-	--chart-1: oklch(0.7 0.18 200);
-	--chart-2: oklch(0.7 0.18 280);
-	--chart-3: oklch(0.7 0.18 320);
-	--chart-4: oklch(0.7 0.18 60);
-	--chart-5: oklch(0.7 0.18 140);
-	/* Additional accent colors for variety */
-	--accent-blue: oklch(0.65 0.18 220);
-	--accent-cyan: oklch(0.65 0.18 190);
-	--accent-purple: oklch(0.65 0.18 280);
-	--accent-green: oklch(0.65 0.18 160);
-	--accent-orange: oklch(0.65 0.18 70);
-	--accent-pink: oklch(0.65 0.18 330);
-	--sidebar: oklch(0.18 0.01 0);
-	--sidebar-foreground: oklch(0.98 0.005 0);
-	--sidebar-primary: oklch(0.63 0.17 270);
-	--sidebar-primary-foreground: oklch(0.98 0.005 0);
-	--sidebar-accent: oklch(0.28 0.02 270);
-	--sidebar-accent-foreground: oklch(0.98 0.005 0);
-	--sidebar-border: oklch(1 0 0 / 12%);
-	--sidebar-ring: oklch(0.58 0.19 270);
-	/* Glassmorphism variables */
-	--glass-bg: oklch(0.18 0.01 0 / 0.7);
-	--glass-border: oklch(1 0 0 / 0.15);
-	--glass-shadow: 0 8px 32px 0 oklch(0 0 0 / 0.37);
-}
-
-.light {
-	/* Light theme moved to .light class */
+	/* Light theme — default */
 	--background: oklch(1 0 0);
 	--foreground: oklch(0.129 0.042 264.695);
 	--card: oklch(1 0 0);
@@ -135,6 +82,55 @@
 	--glass-border: oklch(0.929 0.013 255.508 / 0.5);
 	--glass-shadow: 0 8px 32px 0 oklch(0 0 0 / 0.1);
 }
+
+.dark {
+	/* Dark theme - Neutral gray/charcoal theme */
+	--background: oklch(0.12 0.01 0);
+	--foreground: oklch(0.98 0.005 0);
+	--card: oklch(0.18 0.01 0);
+	--card-foreground: oklch(0.98 0.005 0);
+	--popover: oklch(0.18 0.01 0);
+	--popover-foreground: oklch(0.98 0.005 0);
+
+	/* Blue-Violet/Indigo-Purple */
+	--primary: oklch(0.63 0.17 270);
+	--primary-foreground: oklch(0.98 0.005 0);
+	--ring: oklch(0.58 0.19 270);
+	--accent: oklch(0.28 0.02 270);
+
+	--secondary: oklch(0.25 0.01 0);
+	--secondary-foreground: oklch(0.98 0.005 0);
+	--muted: oklch(0.25 0.01 0);
+	--muted-foreground: oklch(0.65 0.01 0);
+	--accent-foreground: oklch(0.98 0.005 0);
+	--destructive: oklch(0.65 0.22 25);
+	--border: oklch(1 0 0 / 12%);
+	--input: oklch(1 0 0 / 15%);
+	--chart-1: oklch(0.7 0.18 200);
+	--chart-2: oklch(0.7 0.18 280);
+	--chart-3: oklch(0.7 0.18 320);
+	--chart-4: oklch(0.7 0.18 60);
+	--chart-5: oklch(0.7 0.18 140);
+	--accent-blue: oklch(0.65 0.18 220);
+	--accent-cyan: oklch(0.65 0.18 190);
+	--accent-purple: oklch(0.65 0.18 280);
+	--accent-green: oklch(0.65 0.18 160);
+	--accent-orange: oklch(0.65 0.18 70);
+	--accent-pink: oklch(0.65 0.18 330);
+	--sidebar: oklch(0.18 0.01 0);
+	--sidebar-foreground: oklch(0.98 0.005 0);
+	--sidebar-primary: oklch(0.63 0.17 270);
+	--sidebar-primary-foreground: oklch(0.98 0.005 0);
+	--sidebar-accent: oklch(0.28 0.02 270);
+	--sidebar-accent-foreground: oklch(0.98 0.005 0);
+	--sidebar-border: oklch(1 0 0 / 12%);
+	--sidebar-ring: oklch(0.58 0.19 270);
+	--glass-bg: oklch(0.18 0.01 0 / 0.7);
+	--glass-border: oklch(1 0 0 / 0.15);
+	--glass-shadow: 0 8px 32px 0 oklch(0 0 0 / 0.37);
+}
+
+/* .light is now :root — no separate class needed */
 
 @layer base {
 	* {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -66,7 +66,9 @@ export default function LandingPage() {
 
 					<div className="flex flex-col items-center gap-4 sm:flex-row sm:justify-center">
 						<form onSubmit={handleSubmit}>
-							<Button size="lg" className="bg-blue-600 hover:bg-blue-700">
+							<Button
+								size="lg"
+								className="bg-blue-600 text-white hover:bg-blue-700">
 								<Mail className="mr-2 h-5 w-5" />
 								Continue with Gmail
 							</Button>
@@ -75,7 +77,7 @@ export default function LandingPage() {
 							size="lg"
 							variant="outline"
 							onClick={handleDemoClick}
-							className="border-gray-300 bg-white hover:bg-gray-50">
+							className="border-gray-300 bg-white text-gray-700 hover:bg-gray-50 hover:text-gray-900">
 							<Play className="mr-2 h-5 w-5" />
 							Try Demo
 						</Button>
@@ -83,37 +85,37 @@ export default function LandingPage() {
 				</div>
 
 				<div className="mx-auto grid max-w-4xl gap-8 md:grid-cols-3">
-					<Card>
+					<Card className="border-gray-200 bg-white text-gray-900 shadow-md">
 						<CardHeader>
 							<div className="mb-4 flex h-12 w-12 items-center justify-center rounded-lg bg-blue-100">
 								<DollarSign className="h-6 w-6 text-blue-600" />
 							</div>
-							<CardTitle>Bill Management</CardTitle>
-							<CardDescription>
+							<CardTitle className="text-gray-900">Bill Management</CardTitle>
+							<CardDescription className="text-gray-500">
 								Efficiently manage and track all your utility bills in one place
 							</CardDescription>
 						</CardHeader>
 					</Card>
 
-					<Card>
+					<Card className="border-gray-200 bg-white text-gray-900 shadow-md">
 						<CardHeader>
 							<div className="mb-4 flex h-12 w-12 items-center justify-center rounded-lg bg-green-100">
 								<Users className="h-6 w-6 text-green-600" />
 							</div>
-							<CardTitle>Tenant Management</CardTitle>
-							<CardDescription>
+							<CardTitle className="text-gray-900">Tenant Management</CardTitle>
+							<CardDescription className="text-gray-500">
 								Organize tenant information and manage billing relationships
 							</CardDescription>
 						</CardHeader>
 					</Card>
 
-					<Card>
+					<Card className="border-gray-200 bg-white text-gray-900 shadow-md">
 						<CardHeader>
 							<div className="mb-4 flex h-12 w-12 items-center justify-center rounded-lg bg-purple-100">
 								<FileText className="h-6 w-6 text-purple-600" />
 							</div>
-							<CardTitle>Automated Billing</CardTitle>
-							<CardDescription>
+							<CardTitle className="text-gray-900">Automated Billing</CardTitle>
+							<CardDescription className="text-gray-500">
 								Automatically generate and send bills to tenants via email
 							</CardDescription>
 						</CardHeader>

--- a/src/components/app-sidebar/app-sidebar.tsx
+++ b/src/components/app-sidebar/app-sidebar.tsx
@@ -27,7 +27,6 @@ import {
 	AvatarFallback,
 	AvatarImage,
 	Badge,
-	Button,
 	Sidebar,
 	SidebarContent,
 	SidebarFooter,
@@ -214,11 +213,13 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
 						<SidebarMenu>
 							{quickStats.map((stat) => (
 								<SidebarMenuItem key={stat.label}>
-									<SidebarMenuButton>
-										<stat.icon className={`size-4 ${stat.color}`} />
-										<div className="flex flex-1 items-center justify-between">
-											<span className="text-sm">{stat.label}</span>
-											<Badge variant="secondary" className="ml-auto">
+									<SidebarMenuButton
+										className="overflow-hidden"
+										tooltip={`${stat.label}: ${stat.value}`}>
+										<stat.icon className={`size-4 shrink-0 ${stat.color}`} />
+										<div className="flex min-w-0 flex-1 items-center justify-between gap-1">
+											<span className="truncate text-sm">{stat.label}</span>
+											<Badge variant="secondary" className="shrink-0">
 												{stat.value}
 											</Badge>
 										</div>
@@ -231,17 +232,17 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
 
 				<SidebarSeparator />
 
-				{/* Recent Activity Section */}
-				<SidebarGroup>
+				{/* Recent Activity Section — hidden when collapsed */}
+				<SidebarGroup className="group-data-[collapsible=icon]:hidden">
 					<SidebarGroupLabel>Recent Activity</SidebarGroupLabel>
 					<SidebarGroupContent>
 						<SidebarMenu>
 							<SidebarMenuItem>
 								<SidebarMenuButton>
-									<div className="size-4 rounded-full bg-green-500" />
-									<div className="flex flex-col">
-										<span className="text-xs">John Doe paid</span>
-										<span className="text-muted-foreground text-xs">
+									<div className="size-4 shrink-0 rounded-full bg-green-500" />
+									<div className="flex min-w-0 flex-col">
+										<span className="truncate text-xs">John Doe paid</span>
+										<span className="text-muted-foreground truncate text-xs">
 											2 days ago
 										</span>
 									</div>
@@ -249,10 +250,10 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
 							</SidebarMenuItem>
 							<SidebarMenuItem>
 								<SidebarMenuButton>
-									<div className="bg-primary size-4 rounded-full" />
-									<div className="flex flex-col">
-										<span className="text-xs">Bill sent to Jane</span>
-										<span className="text-muted-foreground text-xs">
+									<div className="bg-primary size-4 shrink-0 rounded-full" />
+									<div className="flex min-w-0 flex-col">
+										<span className="truncate text-xs">Bill sent to Jane</span>
+										<span className="text-muted-foreground truncate text-xs">
 											5 days ago
 										</span>
 									</div>
@@ -260,10 +261,10 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
 							</SidebarMenuItem>
 							<SidebarMenuItem>
 								<SidebarMenuButton>
-									<div className="size-4 rounded-full bg-[oklch(0.70_0.18_60)]" />
-									<div className="flex flex-col">
-										<span className="text-xs">New provider added</span>
-										<span className="text-muted-foreground text-xs">
+									<div className="size-4 shrink-0 rounded-full bg-[oklch(0.70_0.18_60)]" />
+									<div className="flex min-w-0 flex-col">
+										<span className="truncate text-xs">New provider added</span>
+										<span className="text-muted-foreground truncate text-xs">
 											1 week ago
 										</span>
 									</div>
@@ -308,7 +309,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
 						</SidebarMenuButton>
 					</SidebarMenuItem>
 					<SidebarMenuItem>
-						<SidebarMenuButton asChild>
+						<SidebarMenuButton asChild tooltip="Settings">
 							<Link href="/dashboard/settings">
 								<Settings className="size-4" />
 								<span>Settings</span>
@@ -316,14 +317,9 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
 						</SidebarMenuButton>
 					</SidebarMenuItem>
 					<SidebarMenuItem>
-						<SidebarMenuButton asChild>
-							<Button
-								variant="ghost"
-								className="flex items-center"
-								onClick={() => handleLogOut()}>
-								<span>Log Out</span>
-								<LogOut className="size-4" />
-							</Button>
+						<SidebarMenuButton onClick={() => handleLogOut()} tooltip="Log Out">
+							<LogOut className="size-4" />
+							<span>Log Out</span>
 						</SidebarMenuButton>
 					</SidebarMenuItem>
 				</SidebarMenu>

--- a/src/components/dashboard/payment-selection-dialog.tsx
+++ b/src/components/dashboard/payment-selection-dialog.tsx
@@ -82,11 +82,20 @@ export const PaymentSelectionDialog: React.FC<PaymentSelectionDialogProps> = ({
 		};
 	});
 
-	// Calculate total selected amount
+	// Calculate total selected amounts
 	const totalSelectedAmount = Array.from(selectedBillIds).reduce(
 		(sum, billId) => {
 			const billAmount = billAmounts.find((ba) => ba.bill.id === billId);
 			return sum + (billAmount?.expectedAmount || 0);
+		},
+		0,
+	);
+
+	// Tenant's pure share (no outstanding balance added) — shown in summary
+	const selectedTenantShare = Array.from(selectedBillIds).reduce(
+		(sum, billId) => {
+			const billAmount = billAmounts.find((ba) => ba.bill.id === billId);
+			return sum + (billAmount?.tenantTotal || 0);
 		},
 		0,
 	);
@@ -193,10 +202,10 @@ export const PaymentSelectionDialog: React.FC<PaymentSelectionDialogProps> = ({
 								</div>
 							</div>
 							<div>
-								<Label className="text-sm font-medium text-gray-500">
+								<Label className="text-muted-foreground text-sm font-medium">
 									Tenant
 								</Label>
-								<p className="text-lg font-medium text-gray-900">
+								<p className="text-foreground text-lg font-medium">
 									{tenant.name}
 								</p>
 							</div>
@@ -205,10 +214,10 @@ export const PaymentSelectionDialog: React.FC<PaymentSelectionDialogProps> = ({
 
 					{/* Unpaid Bills List */}
 					<div>
-						<Label className="text-base font-semibold text-gray-900">
+						<Label className="text-foreground text-base font-semibold">
 							Unpaid Bills
 						</Label>
-						<p className="mb-3 text-sm text-gray-500">
+						<p className="text-muted-foreground mb-3 text-sm">
 							Select the bills this payment applies to
 						</p>
 						<div className="rounded-md border">
@@ -296,27 +305,27 @@ export const PaymentSelectionDialog: React.FC<PaymentSelectionDialogProps> = ({
 
 					{/* Summary */}
 					{selectedBillIds.size > 0 && (
-						<div className="rounded-lg border bg-blue-50 p-4">
+						<div className="bg-muted/40 rounded-lg border p-4">
 							<div className="space-y-2">
 								<div className="flex items-center justify-between">
-									<Label className="text-sm font-medium text-gray-700">
-										Selected Bills Total:
+									<Label className="text-muted-foreground text-sm font-medium">
+										Tenant&#39;s Share:
 									</Label>
-									<span className="text-lg font-semibold text-gray-900">
-										${totalSelectedAmount.toFixed(2)}
+									<span className="text-foreground text-lg font-semibold">
+										${selectedTenantShare.toFixed(2)}
 									</span>
 								</div>
 								<div className="flex items-center justify-between">
-									<Label className="text-sm font-medium text-gray-700">
+									<Label className="text-muted-foreground text-sm font-medium">
 										Payment Amount:
 									</Label>
-									<span className="text-lg font-semibold text-gray-900">
+									<span className="text-foreground text-lg font-semibold">
 										${paymentAmount.toFixed(2)}
 									</span>
 								</div>
 								<div className="border-t pt-2">
 									<div className="flex items-center justify-between">
-										<Label className="text-sm font-medium text-gray-700">
+										<Label className="text-muted-foreground text-sm font-medium">
 											Difference:
 										</Label>
 										<span

--- a/src/components/dashboard/stats-summary.tsx
+++ b/src/components/dashboard/stats-summary.tsx
@@ -42,8 +42,8 @@ export const StatsSummary = ({
 				icon={<DollarSign className="h-5 w-5" />}
 				value={`$${currentMonthTotal.toFixed(2)}`}
 				description={currentDateString}
-				className="border-border from-card bg-gradient-to-br to-[oklch(0.20_0.02_270)]"
-				iconClassName="text-[oklch(0.70_0.18_200)]"
+				className="border-border"
+				iconClassName="text-[oklch(0.50_0.18_200)] dark:text-[oklch(0.70_0.18_200)]"
 			/>
 
 			<StatCard
@@ -51,8 +51,8 @@ export const StatsSummary = ({
 				icon={<TrendingUp className="h-5 w-5" />}
 				value={`$${lastMonthTotal.toFixed(2)}`}
 				description={lastMonthString}
-				className="border-border from-card bg-gradient-to-br to-[oklch(0.20_0.02_60)]"
-				iconClassName="text-[oklch(0.70_0.18_60)]"
+				className="border-border"
+				iconClassName="text-[oklch(0.50_0.18_60)] dark:text-[oklch(0.70_0.18_60)]"
 			/>
 
 			<StatCard
@@ -60,8 +60,8 @@ export const StatsSummary = ({
 				icon={<CheckCircle className="h-5 w-5" />}
 				value={`$${paidAmount.toFixed(2)}`}
 				description="Last month"
-				className="border-border from-card bg-gradient-to-br to-[oklch(0.20_0.02_160)]"
-				iconClassName="text-[oklch(0.70_0.18_160)]"
+				className="border-border"
+				iconClassName="text-[oklch(0.45_0.18_160)] dark:text-[oklch(0.70_0.18_160)]"
 			/>
 
 			<StatCard
@@ -77,10 +77,10 @@ export const StatsSummary = ({
 				description={
 					outstandingBalance < 0 ? "Overpaid amount" : "Unpaid bills"
 				}
-				className="border-border from-card bg-gradient-to-br to-[oklch(0.20_0.02_25)]"
+				className="border-border"
 				iconClassName={
 					outstandingBalance < 0
-						? "text-[oklch(0.70_0.18_190)]"
+						? "text-[oklch(0.50_0.18_190)] dark:text-[oklch(0.70_0.18_190)]"
 						: "text-destructive"
 				}
 			/>

--- a/src/components/providers/providers-page.tsx
+++ b/src/components/providers/providers-page.tsx
@@ -42,10 +42,13 @@ const categoryIcons = {
 };
 
 const categoryColors = {
-	Electricity: "bg-[oklch(0.20_0.02_60)] text-[oklch(0.70_0.18_60)]",
-	Water: "bg-[oklch(0.20_0.02_200)] text-[oklch(0.70_0.18_200)]",
-	Gas: "bg-[oklch(0.20_0.02_25)] text-[oklch(0.70_0.18_25)]",
-	Internet: "bg-[oklch(0.20_0.02_280)] text-[oklch(0.70_0.18_280)]",
+	Electricity:
+		"bg-amber-100 text-amber-700 dark:bg-[oklch(0.20_0.02_60)] dark:text-[oklch(0.70_0.18_60)]",
+	Water:
+		"bg-sky-100 text-sky-700 dark:bg-[oklch(0.20_0.02_200)] dark:text-[oklch(0.70_0.18_200)]",
+	Gas: "bg-orange-100 text-orange-700 dark:bg-[oklch(0.20_0.02_25)] dark:text-[oklch(0.70_0.18_25)]",
+	Internet:
+		"bg-violet-100 text-violet-700 dark:bg-[oklch(0.20_0.02_280)] dark:text-[oklch(0.70_0.18_280)]",
 	OTHER: "bg-muted text-muted-foreground",
 };
 

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -368,7 +368,7 @@ function SidebarContent({ className, ...props }: React.ComponentProps<"div">) {
 			data-slot="sidebar-content"
 			data-sidebar="content"
 			className={cn(
-				"flex min-h-0 flex-1 flex-col gap-2 overflow-auto group-data-[collapsible=icon]:overflow-hidden",
+				"flex min-h-0 flex-1 flex-col gap-2 overflow-x-hidden overflow-y-auto group-data-[collapsible=icon]:overflow-hidden",
 				className,
 			)}
 			{...props}


### PR DESCRIPTION
## Summary

Fixes all reported UI issues across light/dark mode, the landing page, the Payment Detected modal, and the sidebar.

---

### 🎨 Theme — Root Cause Fix (`globals.css`)
- `:root` was incorrectly set to dark theme values, making dark mode the forced default
- Fixed: `:root` now holds the **light theme** (the true default), `.dark` holds the dark palette
- Removed the now-redundant `.light` class alias

### 🏠 Landing Page (`page.tsx`)
- Cards now explicitly use `bg-white text-gray-900` so they render correctly against the hardcoded light-blue gradient background regardless of stored theme preference
- **"Try Demo"** button: added `text-gray-700` so it's always visible (was rendering white-on-white in dark mode)
- **"Continue with Gmail"** button: added explicit `text-white` for safety

### 📊 Dashboard Stat Cards (`stats-summary.tsx`)
- Removed hardcoded dark `oklch` gradient endpoints (`to-[oklch(0.20_0.02_*)]`) that clashed with light mode
- Icon colors now use `dark:` prefixed variants so they adapt correctly per theme

### 🔌 Providers Page (`providers-page.tsx`)
- Category badge colors updated to light-mode-safe Tailwind classes (`bg-amber-100 text-amber-700` etc.) with `dark:` overrides retaining original oklch values

### 💳 Payment Detected Modal (`payment-selection-dialog.tsx`)
- **Tenant name** and **Unpaid Bills** label: replaced hardcoded `text-gray-900/500` with semantic tokens (`text-foreground`, `text-muted-foreground`) — now visible in dark mode
- **Summary section**: replaced `bg-blue-50` (invisible in dark) with `bg-muted/40`
- **Calculation fix**: renamed "Selected Bills Total" → **"Tenant's Share"**, now computed from `tenantTotal` (pure share without outstanding balance). Difference still calculated against `expectedAmount` (which includes balance) for accuracy.

### 📐 Sidebar
- **X-axis overflow** (`sidebar.tsx`): `SidebarContent` changed from `overflow-auto` → `overflow-y-auto overflow-x-hidden`, eliminating the horizontal scrollbar
- **Quick Stats overflow**: inner flex div now has `min-w-0` + `shrink-0` on badge to prevent layout blowout
- **Collapsed state — Recent Activity**: entire section hidden with `group-data-[collapsible=icon]:hidden` (had no icon-only representation)
- **Collapsed state — Log Out**: replaced broken `asChild + Button` pattern with plain `SidebarMenuButton` + `tooltip="Log Out"` — now collapses to icon correctly
- **Settings tooltip**: added `tooltip="Settings"` to the settings `SidebarMenuButton`
- **Quick Stats tooltip**: each stat now shows `"Label: value"` on hover when collapsed