### PR TITLE
fix: use non-deprecated release-please action

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,6 +13,6 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: google-github-actions/release-please-action@v4
+      - uses: googleapis/release-please-action@v4
         with:
           release-type: node


### PR DESCRIPTION
This PR updates the `release-please` workflow to use the non-deprecated action reference (`googleapis/release-please-action` instead of `google-github-actions/release-please-action`).

This addresses the deprecation warning observed in the previous CI run.