### PR TITLE
fix: match display names containing tenant name and search starting from oldest unpaid bill sent date

### DIFF
--- a/src/components/dashboard/dashboard-page.tsx
+++ b/src/components/dashboard/dashboard-page.tsx
@@ -304,18 +304,25 @@ export const DashboardPage = ({ currentMonthBill }: DashboardPageProps) => {
 				return;
 			}
 
-			// Set date range for payment detection (last 30 days)
-			const endDate = new Date();
-			const startDate = new Date();
-			startDate.setDate(startDate.getDate() - 30);
-
-			const dateRange = {
-				start: startDate.toISOString().split("T")[0] ?? "",
-				end: endDate.toISOString().split("T")[0] ?? "",
-			};
-
 			// Check for unused payments (only one at a time to avoid overwhelming the user)
 			for (const tenant of tenantsWithOutstanding) {
+				const endDate = new Date();
+				const unpaidBillsForTenant = billsHistory.filter(
+					(bill) => bill.tenantId === tenant.id && !bill.paid && bill.dateSent,
+				);
+				const earliestDateSent = unpaidBillsForTenant
+					.map((bill) => new Date(bill.dateSent!))
+					.sort((a, b) => a.getTime() - b.getTime())[0];
+
+				const startDate =
+					earliestDateSent ??
+					new Date(endDate.getTime() - 30 * 24 * 60 * 60 * 1000);
+
+				const dateRange = {
+					start: startDate.toISOString().split("T")[0] ?? "",
+					end: endDate.toISOString().split("T")[0] ?? "",
+				};
+
 				const result = await safeExecuteAsync(async () => {
 					return await processTenantPayments(tenant, billsHistory, dateRange);
 				});

--- a/src/lib/gmail/actions.ts
+++ b/src/lib/gmail/actions.ts
@@ -192,7 +192,7 @@ export const queryForBillPayment = async (
 
 		// Try each name in the search
 		for (const name of searchNames) {
-			const query = `from:"${name}" after:${dateRange.start} before:${dateRange.end}`;
+			const query = `from:${name} after:${dateRange.start} before:${dateRange.end}`;
 			const response = await gmailClient.users.messages.list({
 				userId: "me",
 				q: query,
@@ -282,7 +282,7 @@ export const processTenantPayments = async (
 
 		// Try each name in the search
 		for (const name of searchNames) {
-			const query = `from:"${name}" after:${dateRange.start} before:${dateRange.end}`;
+			const query = `from:${name} after:${dateRange.start} before:${dateRange.end}`;
 			const response = await gmailClient.users.messages.list({
 				userId: "me",
 				q: query,


### PR DESCRIPTION
## Description
This PR resolves a bug in payment detection where payments were not detected:
1. Changed Gmail query `from:"${name}"` to `from:${name}` to allow partial name matches (e.g. matching "John Smith" when tenant's name is "John").
2. Modified the search date range to look back to the oldest unpaid bill's `dateSent` dynamically per tenant instead of a hardcoded 30 days.

Both changes have been tested and verified locally.
