### PR TITLE
fix: mobile responsiveness for bill/payment dialogs and payment difference calc

### DIFF
--- a/src/components/bills-history/bills-history-page.tsx
+++ b/src/components/bills-history/bills-history-page.tsx
@@ -692,7 +692,7 @@ export const BillsHistoryPage = () => {
 														View Details
 													</Button>
 												</DialogTrigger>
-												<DialogContent className="max-w-7xl">
+												<DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-7xl">
 													<DialogHeader className="space-y-3">
 														<div className="flex items-center gap-3">
 															<div className="bg-primary/20 rounded-xl p-3">

--- a/src/components/dashboard/payment-selection-dialog.tsx
+++ b/src/components/dashboard/payment-selection-dialog.tsx
@@ -67,31 +67,17 @@ export const PaymentSelectionDialog: React.FC<PaymentSelectionDialogProps> = ({
 
 	const paymentAmount = roundToCurrency(Number(payment.amount));
 
-	// Calculate amounts for each bill
+	// Calculate the tenant's share for each bill
 	const billAmounts = unpaidBills.map((bill) => {
 		const { tenantTotal } = getTenantShares(bill, tenant);
-		// For the first bill in the list, include outstanding balance
-		const isFirstBill = bill === unpaidBills[0];
-		const expectedAmount = isFirstBill
-			? tenantTotal + tenant.outstandingBalance
-			: tenantTotal;
 		return {
 			bill,
 			tenantTotal,
-			expectedAmount,
 		};
 	});
 
-	// Calculate total selected amounts
-	const totalSelectedAmount = Array.from(selectedBillIds).reduce(
-		(sum, billId) => {
-			const billAmount = billAmounts.find((ba) => ba.bill.id === billId);
-			return sum + (billAmount?.expectedAmount || 0);
-		},
-		0,
-	);
-
-	// Tenant's pure share (no outstanding balance added) — shown in summary
+	// Tenant's share across the selected bills — shown in the summary and used
+	// as the basis for the payment difference
 	const selectedTenantShare = Array.from(selectedBillIds).reduce(
 		(sum, billId) => {
 			const billAmount = billAmounts.find((ba) => ba.bill.id === billId);
@@ -100,7 +86,7 @@ export const PaymentSelectionDialog: React.FC<PaymentSelectionDialogProps> = ({
 		0,
 	);
 
-	const difference = paymentAmount - totalSelectedAmount;
+	const difference = paymentAmount - selectedTenantShare;
 	const isExact = Math.abs(difference) <= 0.01;
 	const isOverpaid = difference > 0.01;
 
@@ -151,7 +137,7 @@ export const PaymentSelectionDialog: React.FC<PaymentSelectionDialogProps> = ({
 
 	return (
 		<Dialog open={isOpen} onOpenChange={onClose}>
-			<DialogContent className="max-h-[90vh] max-w-3xl overflow-y-auto">
+			<DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-3xl">
 				<DialogHeader className="space-y-3">
 					<div className="flex items-center gap-3">
 						<div className="bg-primary/20 rounded-xl p-3">
@@ -171,7 +157,7 @@ export const PaymentSelectionDialog: React.FC<PaymentSelectionDialogProps> = ({
 				<div className="space-y-6">
 					{/* Payment Details */}
 					<div className="bg-muted rounded-lg border p-4">
-						<div className="grid grid-cols-2 gap-4">
+						<div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
 							<div>
 								<Label className="text-muted-foreground text-sm font-medium">
 									Payment Amount
@@ -184,7 +170,7 @@ export const PaymentSelectionDialog: React.FC<PaymentSelectionDialogProps> = ({
 								<Label className="text-muted-foreground text-sm font-medium">
 									From
 								</Label>
-								<p className="text-foreground text-lg font-medium">
+								<p className="text-foreground text-lg font-medium break-words">
 									{payment.sentFrom}
 								</p>
 							</div>
@@ -220,7 +206,7 @@ export const PaymentSelectionDialog: React.FC<PaymentSelectionDialogProps> = ({
 						<p className="text-muted-foreground mb-3 text-sm">
 							Select the bills this payment applies to
 						</p>
-						<div className="rounded-md border">
+						<div className="overflow-x-auto rounded-md border">
 							<Table>
 								<TableHeader>
 									<TableRow>


### PR DESCRIPTION
## Summary

Fixes mobile responsiveness issues where two dialog overlays rendered wider than the viewport (content falling off-screen), plus a wrong number in the payment summary.

### Root cause
Both overlays overrode the shared `DialogContent` primitive's mobile-safe width (`max-w-[calc(100%-2rem)]`) with an **unprefixed** larger `max-w-*`, which tailwind-merge replaces entirely — removing the mobile cap.

### Changes

**Bill Details overlay** (`bills-history-page.tsx`)
- `max-w-7xl` → `max-h-[90vh] overflow-y-auto sm:max-w-7xl`, so mobile keeps the 2rem side margin and the (tall) dialog scrolls vertically. Category cards already stack via `md:grid-cols-3`.

**Payment Detected overlay** (`payment-selection-dialog.tsx`)
- `max-w-3xl` → `sm:max-w-3xl` so the dialog keeps a side margin on mobile.
- Wrapped the 4-column bills table in `overflow-x-auto` so it scrolls horizontally instead of overflowing.
- Payment details grid stacks on the smallest screens (`grid-cols-1 sm:grid-cols-2`).
- Added `break-words` to the sender email so long addresses wrap.

**Payment "Difference" calculation** (`payment-selection-dialog.tsx`)
- The summary displays a "Tenant's Share" row but computed the difference against the tenant share **plus** outstanding balance, so the three rows didn't reconcile. Changed to `Payment − Tenant's Share`, and removed the now-unused intermediate calculations.

### Testing
- `pnpm lint` — passes (the one warning is pre-existing in an untouched file).
- `pnpm test:run` — all 75 tests pass (one DB integration file fails only because it can't download the MongoDB binary in this sandbox; unrelated to these changes).
- Manual: verified both dialogs fit a ~375px viewport, table scrolls horizontally, and Difference reconciles with the Tenant's Share and Payment rows.